### PR TITLE
Fixed Buffer() DeprecationWarning

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,10 +25,10 @@ module.exports = function (options) {
 
         if (isBuffer) {
             if(options.keep_comments){
-                file.contents = new Buffer(String(file.contents).replace(pattern, "$1\n$2"));
+                file.contents = Buffer.from(String(file.contents).replace(pattern, "$1\n$2"));
             }
             else{
-                file.contents = new Buffer(String(file.contents).replace(pattern, ""));
+                file.contents = Buffer.from(String(file.contents).replace(pattern, ""));
             }
             return callback(null, file);
         }


### PR DESCRIPTION
[**DEP0005**] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

Source - [https://nodejs.org/dist/latest-v10.x/docs/api/buffer.html#buffer_new_buffer_array](https://nodejs.org/dist/latest-v10.x/docs/api/buffer.html#buffer_new_buffer_array)